### PR TITLE
chore: upgrade guava from 29.0 to 30.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>29.0-jre</version>
+			<version>30.1.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
... in order to fix CVE-2020-8908.
See also: https://github.com/advisories/GHSA-5mg8-w23w-74h3